### PR TITLE
Potential fix for code scanning alert no. 17: Double escaping or unescaping

### DIFF
--- a/src/scripts/test-template-email.js
+++ b/src/scripts/test-template-email.js
@@ -224,12 +224,12 @@ async function sendTemplateEmail(to, templateName) {
       
       // 2. Décoder les entités HTML communes (dans un ordre précis)
       plainText = plainText
-        .replace(/&amp;/g, '&')  // Décoder &amp; en premier pour éviter les doubles décodages
         .replace(/&lt;/g, '<')
         .replace(/&gt;/g, '>')
         .replace(/&quot;/g, '"')
         .replace(/&#39;/g, "'")
-        .replace(/&nbsp;/g, ' ');
+        .replace(/&nbsp;/g, ' ')
+        .replace(/&amp;/g, '&');  // Décoder &amp; en dernier pour éviter les doubles décodages
       
       // 3. Normaliser les espaces
       plainText = plainText.replace(/\s+/g, ' ').trim();


### PR DESCRIPTION
Potential fix for [https://github.com/Sabrsl/vynalplatform/security/code-scanning/17](https://github.com/Sabrsl/vynalplatform/security/code-scanning/17)

To fix the issue, the unescaping logic should be reordered so that `&amp;` is decoded last. This ensures that any `&` characters introduced by earlier replacements (e.g., `&lt;` to `<`) are not incorrectly interpreted as part of another entity. The fix involves moving the `plainText.replace(/&amp;/g, '&')` line to the end of the unescaping sequence.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
