### PR TITLE
Potential fix for code scanning alert no. 19: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "twilio": "^5.5.2",
     "uuid": "^11.1.0",
     "zod": "^3.22.4",
-    "zustand": "^5.0.3"
+    "zustand": "^5.0.3",
+    "sanitize-html": "^2.16.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.1",

--- a/src/scripts/test-template-email.js
+++ b/src/scripts/test-template-email.js
@@ -18,6 +18,7 @@ const templateArg = args.find(arg => !arg.includes('@'));
 
 // Charger les variables d'environnement
 const path = require('path');
+const sanitizeHtml = require('sanitize-html');
 const fs = require('fs');
 const readline = require('readline');
 
@@ -218,9 +219,10 @@ async function sendTemplateEmail(to, templateName) {
     
     // Créer un texte simple alternatif (version sans HTML)
     // Méthode sécurisée pour convertir HTML en texte
+    const sanitizeHtml = require('sanitize-html');
     const text = (() => {
-      // 1. Supprimer les balises HTML
-      let plainText = html.replace(/<[^>]*>/g, '');
+      // 1. Supprimer les balises HTML de manière sécurisée
+      let plainText = sanitizeHtml(html, { allowedTags: [], allowedAttributes: {} });
       
       // 2. Décoder les entités HTML communes (dans un ordre précis)
       plainText = plainText


### PR DESCRIPTION
Potential fix for [https://github.com/Sabrsl/vynalplatform/security/code-scanning/19](https://github.com/Sabrsl/vynalplatform/security/code-scanning/19)

To fix the issue, we need to ensure that all potentially unsafe HTML content, including `<script>` tags and other nested or incomplete tags, is completely removed. A robust approach is to use a well-tested library like `sanitize-html` to sanitize the HTML content. This library is specifically designed to handle complex HTML structures and edge cases, ensuring that no unsafe content remains.

Alternatively, if we want to stick with a custom implementation, we can repeatedly apply the regular expression replacement until no more matches are found. However, using a library is the recommended approach for better reliability and maintainability.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
